### PR TITLE
feat: convert to esm, remove plugin version, update deps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,18 +1,9 @@
 {
-  "extends": [
-    "airbnb-base",
-    "prettier"
-  ],
-  "plugins": [
-    "prettier"
-  ],
+  "extends": ["airbnb-base", "prettier"],
+  "plugins": ["prettier"],
   "rules": {
-    "strict": [
-      0,
-      "global"
-    ],
-    "class-methods-use-this": [
-      0
-    ]
+    "strict": [0, "global"],
+    "class-methods-use-this": [0],
+    "import/extensions": [0]
   }
 }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Ready checks plugin for fastify Node.js web app framework
 ### Basic usage
 
 ```js
-const app = require('fastify')();
-const plugin = require('fastify-ready-checks');
+import fastify from 'fastify';
+import plugin from 'fastify-ready-checks';
+const app = fastify();
 app.register(plugin);
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,8 @@
 /* eslint-disable no-restricted-syntax */
+import fp from 'fastify-plugin';
+import abslog from 'abslog';
 
-'use strict';
-
-const fp = require('fastify-plugin');
-const abslog = require('abslog');
-
-module.exports = fp((fastify, opts, done) => {
+export default fp((fastify, opts, done) => {
     let { live, ready } = opts;
     const { livePathname = '/live', readyPathname = '/ready', logger } = opts;
     const log = abslog(logger);
@@ -78,6 +75,5 @@ module.exports = fp((fastify, opts, done) => {
 
     done();
 }, {
-    fastify: '^3.0.0',
     name: 'fastify-ready-checks',
 });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Ready checks plugin for fastify Node.js web app framework",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "tap",
     "lint:format": "eslint --fix .",
@@ -20,18 +21,18 @@
   },
   "homepage": "https://github.com/finn-no/fastify-ready-checks#readme",
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-config-prettier": "^6.9.0",
-    "eslint-plugin-import": "^2.20.0",
-    "eslint-plugin-prettier": "^3.1.2",
-    "fastify": "^3.2.1",
-    "prettier": "^1.19.1",
-    "supertest": "^4.0.2",
-    "tap": "^14.10.6"
+    "eslint": "^8.34.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "fastify": "^4.13.0",
+    "prettier": "^2.8.4",
+    "supertest": "^6.3.3",
+    "tap": "^16.3.4"
   },
   "dependencies": {
     "abslog": "2.4.0",
-    "fastify-plugin": "2.3.1"
+    "fastify-plugin": "^4.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const { test } = require('tap');
-const fastify = require('fastify');
-const supertest = require('supertest');
-const plugin = require('./index');
+import { test } from 'tap';
+import fastify from 'fastify';
+import supertest from 'supertest';
+import plugin from './index.js';
 
 test('Plugin default behaviour', async t => {
     const app = fastify();


### PR DESCRIPTION
BREAKING CHANGE: Common JS no longer supported

Same deal as https://github.com/finn-no/fastify-metrics-js-response-timing/pull/3